### PR TITLE
Ensure localStorage is not fired in the source window with IE9/10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var generateUuid = require('generate-uuid');
 var constants = require('redux-persist/constants');
 var keyPrefix = constants.keyPrefix;
 
@@ -5,32 +6,136 @@ module.exports = function(persistor, config) {
   var newConfig = config || {};
   var blacklist = newConfig.blacklist || false;
   var whitelist = newConfig.whitelist || false;
+
+  var guid = generateUuid();
   var isFocused = (document.hasFocus) ? document.hasFocus() : true;
+  var others = {};
 
-  window.addEventListener('focus', function () {
-    isFocused = true;
-  }, false);
+  var props = {
+    isMaster: false,
+    checkTimeout: null,
+    pingTimeout: null
+  }
 
-  window.addEventListener('blur', function () {
-    isFocused = false;
-  }, false);
+  var control = {
+    check: function () {
+      var now = +new Date(), takeMaster = true, id;
+      for (id in others) {
+        if (others[id] + 23000 < now) {
+          delete others[id];
+        } else if (id < guid) {
+          takeMaster = false;
+        }
+      }
 
-  window.addEventListener('storage', function (event) {
-    if (isFocused) return;
-    //|| !event.newValue
-    console.log('isFocused::: ', isFocused);
-    console.log('handleStorageEvent::: key ', event.key);
-    console.log('handleStorageEvent::: oldValue ', event.oldValue);
-    console.log('handleStorageEvent::: newValue ', event.newValue);
+      if (props.isMaster !== takeMaster) {
+        props.isMaster = takeMaster;
+        this.masterDidChange();
+      }
+      console.log('check::: ', now, props.isMaster);
+    },
+    ping: function (event) {
+      others[event.id] = +new Date();
+      console.log('ping', others);
+    },
+    hello: function (event) {
+      this.ping(event);
+      if (event.id < guid) {
+        this.check();
+      } else {
+        this.broadcast('ping');
+      }
+    },
+    bye: function (event) {
 
-    if (event.key.indexOf(keyPrefix) === 0) {
-      var keyspace = event.key.substr(keyPrefix.length);
-      if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
-      if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
-      // rehydrate storage with the new value
-      persistor.rehydrate(keyspace, event.newValue, function (oldState, newState) {
-        // @TODO handle errors?
-      });
+    },
+    broadcast: function (type, data) {
+      var event = { id: guid, type: type };
+
+      for (var x in data) {
+        event[x] = data[x];
+      }
+
+      try {
+        localStorage.setItem('broadcast', JSON.stringify(event));
+      } catch (error) {
+        console.log(error);
+      }
+      console.log('broadcast::: ', type, data, JSON.stringify(event));
+    },
+    masterDidChange: function () {
+      console.log('masterDidChange', guid);
     }
-  }, false);
+  };
+
+  var events = {
+    focus: function () {
+      isFocused = !isFocused;
+      console.log('events.focus', isFocused);
+    },
+    destroy: function () {
+      window.removeEventListener('focus', this.focus, false);
+      window.removeEventListener('blur', this.focus, false);
+      window.removeEventListener('storage', this.storage, false);
+      window.removeEventListener('unload', this.destroy, false);
+    },
+    storage: function (event) {
+      //if (isFocused) return;
+
+      console.log('isFocused::: ', isFocused);
+      console.log('handleStorageEvent::: key ', event.key);
+      console.log('handleStorageEvent::: oldValue ', event.oldValue);
+      console.log('handleStorageEvent::: newValue ', event.newValue);
+
+      switch (event.type) {
+        case 'storage':
+          if (event.key === 'broadcast') {
+            try {
+              var data = JSON.parse(event.newValue);
+              console.log('BROADCAST DATA::: ', data);
+              if (data.id !== guid) {
+                control[data.type](data);
+              }
+            } catch (error) {
+              console.log(error);
+            }
+          }
+
+          if (event.key.indexOf(keyPrefix) === 0) {
+            var keyspace = event.key.substr(keyPrefix.length);
+            if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
+            if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
+            // rehydrate storage with the new value
+            persistor.rehydrate(keyspace, event.newValue, function (key, state) {
+              // @TODO handle errors?
+            });
+          }
+          break;
+        case 'unload':
+          destroy();
+          break;
+      };
+    }
+  };
+
+  var timeout = {
+    check: function () {
+      control.check();
+      props.checkTimeout = setTimeout(timeout.check, 9000);
+    },
+    ping: function () {
+      control.broadcast('ping');
+      props.pingTimeout = setTimeout(timeout.ping, 17000);
+    }
+  };
+
+  window.addEventListener('focus', events.focus, false);
+  window.addEventListener('blur', events.focus, false);
+  window.addEventListener('unload', events.destroy, false);
+  window.addEventListener('storage', events.storage, false);
+
+  props.checkTimeout = setTimeout(timeout.check, 500);
+  props.pingTimeout = setTimeout(timeout.ping, 17000);
+
+  control.broadcast('hello');
 };

--- a/index.js
+++ b/index.js
@@ -1,22 +1,31 @@
 var constants = require('redux-persist/constants');
 var keyPrefix = constants.keyPrefix;
 
-module.exports = function (persistor, config) {
+module.exports = function(persistor, config) {
   var newConfig = config || {};
   var blacklist = newConfig.blacklist || false;
   var whitelist = newConfig.whitelist || false;
+  var isFocused = (document.hasFocus) ? document.hasFocus() : true;
 
-  window.addEventListener('storage', handleStorageEvent, false);
+  window.addEventListener('focus', function () {
+    isFocused = true;
+  }, false);
 
-  function handleStorageEvent(e) {
-    if (e.key.indexOf(keyPrefix) === 0) {
-      var keyspace = e.key.substr(keyPrefix.length);
+  window.addEventListener('blur', function () {
+    isFocused = false;
+  }, false);
+
+  window.addEventListener('storage', function (event) {
+    if (isFocused || !event.newValue) return;
+
+    if (event.key.indexOf(keyPrefix) === 0) {
+      var keyspace = event.key.substr(keyPrefix.length);
       if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
       if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
 
-      persistor.rehydrate(keyspace, e.newValue, function () {
-        //@TODO handle errors?
-      })
+      persistor.rehydrate(keyspace, event.newValue, function (oldState, newState) {
+        // @TODO handle errors?
+      });
     }
-  }
+  }, false);
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var generateUuid = require('generate-uuid');
 var constants = require('redux-persist/constants');
 var keyPrefix = constants.keyPrefix;
 
@@ -6,138 +5,27 @@ module.exports = function(persistor, config) {
   var newConfig = config || {};
   var blacklist = newConfig.blacklist || false;
   var whitelist = newConfig.whitelist || false;
-
-  var guid = generateUuid();
   var isFocused = (document.hasFocus) ? document.hasFocus() : true;
-  var others = {};
 
-  var props = {
-    isMaster: false,
-    checkTimeout: null,
-    pingTimeout: null
-  };
+  window.addEventListener('focus', function () {
+    isFocused = true;
+  }, false);
 
-  var control = {
-    check: function () {
-      var now = +new Date(), takeMaster = true;
-      for (var id in others) {
-        if (others.hasOwnProperty(id)) {
-          if (others[id] + 23000 < now) {
-            delete others[id];
-          } else if (id < guid) {
-            takeMaster = false;
-          }
-        }
-      }
+  window.addEventListener('blur', function () {
+    isFocused = false;
+  }, false);
 
-      if (props.isMaster !== takeMaster) {
-        props.isMaster = takeMaster;
-        this.masterDidChange();
-      }
-      console.log('check::: ', now, props.isMaster);
-    },
-    ping: function (event) {
-      others[event.id] = +new Date();
-      console.log('ping', others);
-    },
-    hello: function (event) {
-      this.ping(event);
-      if (event.id < guid) {
-        this.check();
-      } else {
-        this.broadcast('ping');
-      }
-    },
-    bye: function (event) {
+  window.addEventListener('storage', function (event) {
+    if (isFocused) return;
 
-    },
-    broadcast: function (type, data) {
-      var event = { id: guid, type: type };
-
-      for (var x in data) {
-        event[x] = data[x];
-      }
-
-      try {
-        localStorage.setItem('broadcast', JSON.stringify(event));
-      } catch (error) {
-        console.log(error);
-      }
-      console.log('broadcast::: ', type, data, JSON.stringify(event));
-    },
-    masterDidChange: function () {
-      console.log('masterDidChange', guid);
+    if (event.key.indexOf(keyPrefix) === 0) {
+      var keyspace = event.key.substr(keyPrefix.length);
+      if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
+      if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
+      // rehydrate storage with the new value
+      persistor.rehydrate(keyspace, event.newValue, function (key, state) {
+        // @TODO handle errors?
+      });
     }
-  };
-
-  var events = {
-    focus: function () {
-      isFocused = !isFocused;
-      console.log('events.focus', isFocused);
-    },
-    destroy: function () {
-      window.removeEventListener('focus', this.focus, false);
-      window.removeEventListener('blur', this.focus, false);
-      window.removeEventListener('storage', this.storage, false);
-      window.removeEventListener('unload', this.destroy, false);
-    },
-    storage: function (event) {
-      //if (isFocused) return;
-
-      console.log('isFocused::: ', isFocused);
-      console.log('handleStorageEvent::: key ', event.key);
-      console.log('handleStorageEvent::: oldValue ', event.oldValue);
-      console.log('handleStorageEvent::: newValue ', event.newValue);
-
-      switch (event.type) {
-        case 'storage':
-          if (event.key === 'broadcast') {
-            try {
-              var data = JSON.parse(event.newValue);
-              console.log('BROADCAST DATA::: ', data);
-              if (data.id !== guid) {
-                control[data.type](data);
-              }
-            } catch (error) {
-              console.log(error);
-            }
-          }
-
-          if (event.key.indexOf(keyPrefix) === 0) {
-            var keyspace = event.key.substr(keyPrefix.length);
-            if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
-            if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
-            // rehydrate storage with the new value
-            persistor.rehydrate(keyspace, event.newValue, function (key, state) {
-              // @TODO handle errors?
-            });
-          }
-          break;
-        case 'unload':
-          destroy();
-          break;
-      };
-    }
-  };
-
-  var timeout = {
-    check: function () {
-      control.check();
-      props.checkTimeout = setTimeout(timeout.check, 9000);
-    },
-    ping: function () {
-      control.broadcast('ping');
-      props.pingTimeout = setTimeout(timeout.ping, 17000);
-    }
-  };
-
-  window.addEventListener('focus', events.focus, false);
-  window.addEventListener('blur', events.focus, false);
-  window.addEventListener('unload', events.destroy, false);
-  window.addEventListener('storage', events.storage, false);
-
-  props.checkTimeout = setTimeout(timeout.check, 500);
-  props.pingTimeout = setTimeout(timeout.ping, 17000);
-
-  control.broadcast('hello');
+  }, false);
 };

--- a/index.js
+++ b/index.js
@@ -15,16 +15,18 @@ module.exports = function(persistor, config) {
     isMaster: false,
     checkTimeout: null,
     pingTimeout: null
-  }
+  };
 
   var control = {
     check: function () {
-      var now = +new Date(), takeMaster = true, id;
-      for (id in others) {
-        if (others[id] + 23000 < now) {
-          delete others[id];
-        } else if (id < guid) {
-          takeMaster = false;
+      var now = +new Date(), takeMaster = true;
+      for (var id in others) {
+        if (others.hasOwnProperty(id)) {
+          if (others[id] + 23000 < now) {
+            delete others[id];
+          } else if (id < guid) {
+            takeMaster = false;
+          }
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -17,12 +17,18 @@ module.exports = function(persistor, config) {
 
   window.addEventListener('storage', function (event) {
     if (isFocused) return;
+    //|| !event.newValue
+    console.log('isFocused::: ', isFocused);
+    console.log('handleStorageEvent::: key ', event.key);
+    console.log('handleStorageEvent::: oldValue ', event.oldValue);
+    console.log('handleStorageEvent::: newValue ', event.newValue);
+
     if (event.key.indexOf(keyPrefix) === 0) {
-      var keySpace = event.key.substr(keyPrefix.length);
-      if (whitelist && whitelist.indexOf(keySpace) === -1) { return; }
-      if (blacklist && blacklist.indexOf(keySpace) !== -1) { return; }
+      var keyspace = event.key.substr(keyPrefix.length);
+      if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
+      if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
       // rehydrate storage with the new value
-      persistor.rehydrate(keySpace, event.newValue, function (key, state) {
+      persistor.rehydrate(keyspace, event.newValue, function (oldState, newState) {
         // @TODO handle errors?
       });
     }

--- a/index.js
+++ b/index.js
@@ -16,16 +16,21 @@ module.exports = function(persistor, config) {
   }, false);
 
   window.addEventListener('storage', function (event) {
-    if (isFocused || !event.newValue) return;
+    if (isFocused) return;
+    //|| !event.newValue
+    console.log('isFocused::: ', isFocused);
+    console.log('handleStorageEvent::: key ', event.key);
+    console.log('handleStorageEvent::: oldValue ', event.oldValue);
+    console.log('handleStorageEvent::: newValue ', event.newValue);
 
     if (event.key.indexOf(keyPrefix) === 0) {
       var keyspace = event.key.substr(keyPrefix.length);
       if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
       if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
-
+      // rehydrate storage with the new value
       persistor.rehydrate(keyspace, event.newValue, function (oldState, newState) {
         // @TODO handle errors?
       });
     }
   }, false);
-}
+};

--- a/index.js
+++ b/index.js
@@ -17,12 +17,6 @@ module.exports = function(persistor, config) {
 
   window.addEventListener('storage', function (event) {
     if (isFocused) return;
-    //|| !event.newValue
-    console.log('isFocused::: ', isFocused);
-    console.log('handleStorageEvent::: key ', event.key);
-    console.log('handleStorageEvent::: oldValue ', event.oldValue);
-    console.log('handleStorageEvent::: newValue ', event.newValue);
-
     if (event.key.indexOf(keyPrefix) === 0) {
       var keyspace = event.key.substr(keyPrefix.length);
       if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
-var constants = require('redux-persist/constants')
-var keyPrefix = constants.keyPrefix
+var constants = require('redux-persist/constants');
+var keyPrefix = constants.keyPrefix;
 
-module.exports = function(persistor, config){
-  var config = config || {}
-  var blacklist = config.blacklist || false
-  var whitelist = config.whitelist || false
+module.exports = function (persistor, config) {
+  var newConfig = config || {};
+  var blacklist = newConfig.blacklist || false;
+  var whitelist = newConfig.whitelist || false;
 
-  window.addEventListener('storage', handleStorageEvent, false)
+  window.addEventListener('storage', handleStorageEvent, false);
 
-  function handleStorageEvent(e){
-    if(e.key.indexOf(keyPrefix) === 0){
-      var keyspace = e.key.substr(keyPrefix.length)
-      if(whitelist && whitelist.indexOf(keyspace) === -1){ return }
-      if(blacklist && blacklist.indexOf(keyspace) !== -1){ return }
-      
-      persistor.rehydrate(keyspace, e.newValue, function(){
+  function handleStorageEvent(e) {
+    if (e.key.indexOf(keyPrefix) === 0) {
+      var keyspace = e.key.substr(keyPrefix.length);
+      if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
+      if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
+
+      persistor.rehydrate(keyspace, e.newValue, function () {
         //@TODO handle errors?
       })
     }

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ module.exports = function(persistor, config) {
   window.addEventListener('storage', function (event) {
     if (isFocused) return;
     if (event.key.indexOf(keyPrefix) === 0) {
-      var keyspace = event.key.substr(keyPrefix.length);
-      if (whitelist && whitelist.indexOf(keyspace) === -1) { return; }
-      if (blacklist && blacklist.indexOf(keyspace) !== -1) { return; }
+      var keySpace = event.key.substr(keyPrefix.length);
+      if (whitelist && whitelist.indexOf(keySpace) === -1) { return; }
+      if (blacklist && blacklist.indexOf(keySpace) !== -1) { return; }
       // rehydrate storage with the new value
-      persistor.rehydrate(keyspace, event.newValue, function (oldState, newState) {
+      persistor.rehydrate(keySpace, event.newValue, function (key, state) {
         // @TODO handle errors?
       });
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "redux-rehydrate"
   ],
   "peerDependencies": {
-    "redux-persist": ">0.5.0"
+    "redux-persist": ">0.5.0",
+    "generate-uuid": "1.x"
   },
   "author": "rt2zz <zack@root-two.com>",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "redux-rehydrate"
   ],
   "peerDependencies": {
-    "redux-persist": ">0.5.0",
-    "generate-uuid": "1.x"
+    "redux-persist": ">0.5.0"
   },
   "author": "rt2zz <zack@root-two.com>",
   "license": "MIT"


### PR DESCRIPTION
HTML5 localStorage implementation in IE 9/10 does not match the spec. This is a known issue and the pull request addresses a work-around. Please test and feedback any changes required. See link below for more details on the problem. 

https://connect.microsoft.com/IE/feedback/details/774798/localstorage-event-fired-in-source-window
