### PR TITLE
Update for 3.5.0 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var constants = require('redux-persist/constants')
-var keyPrefix = constants.keyPrefix
+var KEY_PREFIX = constants.KEY_PREFIX
 
 module.exports = function(persistor, config){
   var config = config || {}
@@ -9,8 +9,8 @@ module.exports = function(persistor, config){
   window.addEventListener('storage', handleStorageEvent, false)
 
   function handleStorageEvent(e){
-    if(e.key.indexOf(keyPrefix) === 0){
-      var keyspace = e.key.substr(keyPrefix.length)
+    if(e.key.indexOf(KEY_PREFIX) === 0){
+      var keyspace = e.key.substr(KEY_PREFIX.length)
       if(whitelist && whitelist.indexOf(keyspace) === -1){ return }
       if(blacklist && blacklist.indexOf(keyspace) !== -1){ return }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-persist-crosstab",
-  "version": "3.0.0",
+  "version": "3.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "redux-rehydrate"
   ],
   "peerDependencies": {
-    "redux-persist": ">0.5.0"
+    "redux-persist": ">3.5.0"
   },
   "author": "rt2zz <zack@root-two.com>",
   "license": "MIT"


### PR DESCRIPTION
Looks like redux-persist 3.5.0 did not follow semver.
