### PR TITLE
Makes keyPrefix configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,13 @@ module.exports = function(persistor, config){
   var config = config || {}
   var blacklist = config.blacklist || false
   var whitelist = config.whitelist || false
+  var keyPrefix = config.keyPrefix || KEY_PREFIX
 
   window.addEventListener('storage', handleStorageEvent, false)
 
   function handleStorageEvent(e){
-    if(e.key.indexOf(KEY_PREFIX) === 0){
-      var keyspace = e.key.substr(KEY_PREFIX.length)
+    if(e.key.indexOf(keyPrefix) === 0){
+      var keyspace = e.key.substr(keyPrefix.length)
       if(whitelist && whitelist.indexOf(keyspace) === -1){ return }
       if(blacklist && blacklist.indexOf(keyspace) !== -1){ return }
 


### PR DESCRIPTION
Right now, if you choose to specify `keyPrefix` in your redux-persist configuration, you won't be able to use redux-persist-crosstab. This PR fixes the issue by allowing you to specify `keyPrefix` in config.