### PR TITLE
Only calls rehydrate if old and new values differ

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function(persistor, config){
       var keyspace = e.key.substr(keyPrefix.length)
       if(whitelist && whitelist.indexOf(keyspace) === -1){ return }
       if(blacklist && blacklist.indexOf(keyspace) !== -1){ return }
+      if(e.oldValue === e.newValue){ return }
 
       var statePartial = {}
       statePartial[keyspace] = e.newValue


### PR DESCRIPTION
See https://github.com/rt2zz/redux-persist-crosstab/issues/9 

IE 11 seems to get stuck in an infinite loop of `storage` events sometimes. By only rehydrating if the old and new values aren't the same, this problems seems to be fixed *yaay*