### PR TITLE
v5 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,13 +20,6 @@ module.exports = function (store: Store, persistConfig: PersistConfig, crosstabC
 
   function handleStorageEvent (e) {
     if (e.key && e.key.indexOf(keyPrefix) === 0) {
-      const keyspace: string = e.key.substr(keyPrefix.length)
-      if (whitelist && whitelist.indexOf(keyspace) === -1) {
-        return
-      }
-      if (blacklist && blacklist.indexOf(keyspace) !== -1) {
-        return
-      }
       if (e.oldValue === e.newValue) {
         return
       }
@@ -36,7 +29,15 @@ module.exports = function (store: Store, persistConfig: PersistConfig, crosstabC
       /* eslint-disable flowtype/no-weak-types */
       const state: Object = Object.keys(statePartial).reduce((state, reducerKey) => {
         /* eslint-enable flowtype/no-weak-types */
+        if (whitelist && whitelist.indexOf(reducerKey) === -1) {
+          return state
+        }
+        if (blacklist && blacklist.indexOf(reducerKey) !== -1) {
+          return state
+        }
+
         state[reducerKey] = JSON.parse(statePartial[reducerKey])
+
         return state
       }, {})
 

--- a/index.js
+++ b/index.js
@@ -1,24 +1,50 @@
-var constants = require('redux-persist/constants')
-var KEY_PREFIX = constants.KEY_PREFIX
+// @flow
+import { KEY_PREFIX, REHYDRATE } from 'redux-persist/lib/constants'
+import type { PersistConfig } from 'redux-persist/es/types'
+import type { Store } from 'redux'
 
-module.exports = function(persistor, config){
-  var config = config || {}
-  var blacklist = config.blacklist || false
-  var whitelist = config.whitelist || false
-  var keyPrefix = config.keyPrefix || KEY_PREFIX
+type CrosstabConfig = {
+  blacklist?: ?Array<string>,
+  keyPrefix?: ?string,
+  whitelist?: ?Array<string>,
+}
+
+module.exports = function (store: Store, persistConfig: PersistConfig, crosstabConfig: CrosstabConfig = {}) {
+  const blacklist: ?Array<string> = crosstabConfig.blacklist || null
+  const whitelist: ?Array<string> = crosstabConfig.whitelist || null
+  const keyPrefix: string = crosstabConfig.keyPrefix || KEY_PREFIX
+
+  const { key }: { key: string } = persistConfig
 
   window.addEventListener('storage', handleStorageEvent, false)
 
-  function handleStorageEvent(e){
-    if(e.key && e.key.indexOf(keyPrefix) === 0){
-      var keyspace = e.key.substr(keyPrefix.length)
-      if(whitelist && whitelist.indexOf(keyspace) === -1){ return }
-      if(blacklist && blacklist.indexOf(keyspace) !== -1){ return }
-      if(e.oldValue === e.newValue){ return }
+  function handleStorageEvent (e) {
+    if (e.key && e.key.indexOf(keyPrefix) === 0) {
+      const keyspace: string = e.key.substr(keyPrefix.length)
+      if (whitelist && whitelist.indexOf(keyspace) === -1) {
+        return
+      }
+      if (blacklist && blacklist.indexOf(keyspace) !== -1) {
+        return
+      }
+      if (e.oldValue === e.newValue) {
+        return
+      }
 
-      var statePartial = {}
-      statePartial[keyspace] = e.newValue
-      persistor.rehydrate(statePartial, {serial: true})
+      const statePartial: { [string]: string } = JSON.parse(e.newValue)
+
+      /* eslint-disable flowtype/no-weak-types */
+      const state: Object = Object.keys(statePartial).reduce((state, reducerKey) => {
+        /* eslint-enable flowtype/no-weak-types */
+        state[reducerKey] = JSON.parse(statePartial[reducerKey])
+        return state
+      }, {})
+
+      store.dispatch({
+        key,
+        payload: state,
+        type: REHYDRATE,
+      })
     }
   }
 }


### PR DESCRIPTION
Not sure exactly what needs to be done to get a PR in here as there are no tests or guidelines but here is the crosstab persist I wrote for our app for v5. From conversation in #15 and https://github.com/rt2zz/redux-persist/issues/569

I’m using it like this:

```js
// @flow

import { applyMiddleware, createStore } from 'redux'
import { persistCombineReducers, persistStore } from 'redux-persist'
import { routerMiddleware, routerReducer } from 'react-router-redux'
import createHistory from 'history/createBrowserHistory'
import logger from 'redux-logger'
import persistCrosstab from './persistCrosstab'
import reducers from '../reducers'
import storage from 'redux-persist/es/storage'
import type { PersistConfig, Persistor } from 'redux-persist/es/types'
import type { Store } from 'redux'

export const history: History = createHistory()

const persistConfig: PersistConfig = {
  key: 'root',
  storage,
  whitelist: ['ui'], // Reducers to persist in localstorage.
}

const store: Store = createStore(
  persistCombineReducers(persistConfig, {
    ...reducers,
    router: routerReducer,
  }),
  applyMiddleware(logger, routerMiddleware(history))
)

export const persistor: Persistor = persistStore(store, undefined, () => {
  // `store.getState()` becomes available in this callback.
})

persistCrosstab(store, persistConfig, {
  whitelist: ['ui'], // Reducers to persist crosstab.
})

export default store
```